### PR TITLE
feat: added clean customization pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,16 @@ repos:
         language: system
         types: [python]
 
+  - repo: local
+    hooks:
+      - id: clean_customized_doctypes
+        always_run: true
+        # give app_name in entry python3 pre-commit/clean_customized_doctypes.py {app_name}
+        name: pre-commit/clean_customized_doctypes.py
+        entry: python3 pre-commit/clean_customized_doctypes.py {app_name}
+        language: system
+        types: [python]
+
 ci:
   autoupdate_schedule: weekly
   skip: []

--- a/pre-commit/clean_customized_doctypes.py
+++ b/pre-commit/clean_customized_doctypes.py
@@ -1,0 +1,54 @@
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+
+def scrub(txt: str) -> str:
+	"""Returns sluggified string. e.g. `Sales Order` becomes `sales_order`."""
+	return txt.replace(" ", "_").replace("-", "_").lower()
+
+def get_customized_doctypes(app):
+	customized_doctypes = {}
+
+	app_dir = pathlib.Path(__file__).resolve().parent.parent.parent / app
+	if not app_dir.is_dir():
+		return customized_doctypes
+
+	modules = (app_dir / app / "modules.txt").read_text().split("\n")
+	for module in modules:
+		if not (app_dir / app / scrub(module) / "custom").exists():
+			continue
+	
+		for custom_file in list((app_dir / app / scrub(module) / "custom").glob("**/*.json")):
+			if custom_file.stem in customized_doctypes:
+				customized_doctypes[custom_file.stem].append(custom_file.resolve())
+			else:
+				customized_doctypes[custom_file.stem] = [custom_file.resolve()]
+
+	return customized_doctypes
+
+def validate_and_clean_customized_doctypes(customized_doctypes):
+	for doctype, customize_files in customized_doctypes.items():
+		for customize_file in customize_files:
+			temp_file_path = tempfile.mktemp()
+			with open(customize_file, "r") as f, open(temp_file_path, "w") as temp_file:
+				file_contents = json.load(f)
+				for key, value in list(file_contents.items()):
+					if isinstance(value, list):
+						for item in value:
+							for item_key, item_value in list(item.items()):
+								if item_value is None and item_key not in ["default", "value"]:
+									del item[item_key]
+
+					elif value is None and key not in ["default", "value"]:
+						del file_contents[key]
+
+				temp_file.write(json.dumps(file_contents, indent="\t", sort_keys=True))
+				os.replace(temp_file_path, customize_file)
+
+if __name__ == "__main__":
+	if sys.argv[1]:
+		customized_doctypes = get_customized_doctypes(sys.argv[1])
+		validate_and_clean_customized_doctypes(customized_doctypes)


### PR DESCRIPTION
Added clean customization pre-commit config. Issue - https://github.com/agritheory/test_utils/issues/5

- [x] Remove unused keys in customizations
- [x] Don't remove "default" key, even when it evaluates to False
- [x] Don't remove "value" key, even when it evaluates to False

While adding a hook to pre-commit in other repos, pass the app name to `entry` in the hook.
`entry: python3 pre-commit/clean_customized_doctypes.py {app_name}` replace app_name with actual app name.
eg. `entry: python3 pre-commit/clean_customized_doctypes.py cloud_storage`