### PR TITLE
feat: update validate_copyright to work as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: validate_copyright
+  name: validate_copyright
+  description: "Validate Copyright"
+  entry: validate_copyright
+  files: '\.(js|ts|py|md)$'
+  language: python

--- a/docs/pre_commit_hooks.md
+++ b/docs/pre_commit_hooks.md
@@ -1,0 +1,18 @@
+## Using test_utils with pre-commit
+
+Add this to your .pre-commit-config.yaml
+
+### Hooks available
+
+### Validate Copyright - `validate_copyright` 
+
+Check all *.js, *.ts, *.py, and *.md files and add copyright in these files if copyright doesn't exist.
+
+```
+  - repo: https://github.com/agritheory/test_utils/
+    rev: {rev}
+    hooks:
+      - id: validate_copyright
+        files: '\.(js|ts|py|md)$'
+        args: ["--app", "{app_name}"]
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ packages = [
 	{include = "test_utils"}
 ]
 
+[tool.poetry.scripts]
+validate_copyright = "test_utils.pre_commit.validate_copyright:main"
+
 [tool.poetry.dependencies]
 python = "^3.8"
 


### PR DESCRIPTION
Issue - https://github.com/agritheory/test_utils/issues/40
Update validate_copyright to work as pre-commit hook
To use this as pre-commit hook - 
```
  - repo: https://github.com/agritheory/test_utils/
    rev: {rev}
    hooks:
      - id: validate_copyright
        files: '\.(js|ts|py|md)$'
        args: ["--app", "cloud_storage"]
```