### PR TITLE
feat: update validate_python_dependencies to work as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,9 @@
   entry: validate_copyright
   files: '\.(js|ts|py|md)$'
   language: python
+- id: validate_python_dependencies
+  name: validate_python_dependencies
+  description: "Examine pyptoject.toml across the installed apps on the site to detect any version mismatches"
+  entry: validate_python_dependencies
+  language: python
+  require_serial: true

--- a/docs/pre_commit_hooks.md
+++ b/docs/pre_commit_hooks.md
@@ -10,9 +10,20 @@ Check all *.js, *.ts, *.py, and *.md files and add copyright in these files if c
 
 ```
   - repo: https://github.com/agritheory/test_utils/
-    rev: {rev}
+    rev: {rev} // The revision or tag to clone. Example: rev: v0.3.0
     hooks:
       - id: validate_copyright
         files: '\.(js|ts|py|md)$'
         args: ["--app", "{app_name}"]
+```
+
+### Validate python dependencies - `validate_python_dependencies` 
+
+Examine pyproject.toml across the installed apps on the site to detect any version mismatches
+
+```
+  - repo: https://github.com/agritheory/test_utils/
+    rev: {rev} // The revision or tag to clone. Example: rev: v0.3.0
+    hooks:
+      - id: 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [
 
 [tool.poetry.scripts]
 validate_copyright = "test_utils.pre_commit.validate_copyright:main"
+validate_python_dependencies = "test_utils.pre_commit.validate_python_dependencies:main"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/test_utils/pre_commit/validate_python_dependencies.py
+++ b/test_utils/pre_commit/validate_python_dependencies.py
@@ -1,10 +1,12 @@
 
+import argparse
 import pathlib
 import sys
 import toml
+from typing import Sequence
 
 def get_dependencies(app):
-	apps_dir = pathlib.Path(__file__).resolve().parent.parent.parent
+	apps_dir = pathlib.Path().resolve().parent
 	if pathlib.Path.exists(apps_dir / app / "pyproject.toml"):
 		with open(apps_dir / app / "pyproject.toml") as f:
 			return toml.load(f)
@@ -37,7 +39,7 @@ def get_versions(app):
 	return dependency_objects
 
 def get_mismatched_versions():
-	apps_order = pathlib.Path(__file__).resolve().parent.parent.parent.parent / "sites" / "apps.txt"
+	apps_order = pathlib.Path().resolve().parent.parent / "sites" / "apps.txt"
 	apps_order = apps_order.read_text().split("\n")
 	exceptions = []
 	app_packages = {app: get_versions(app) for app in apps_order}
@@ -57,14 +59,16 @@ def get_mismatched_versions():
 	return exceptions
 
 
-if __name__ == "__main__":
-	exceptions = get_mismatched_versions()
+def main(argv: Sequence[str] = None):
+	parser = argparse.ArgumentParser()
+	parser.add_argument("filenames", nargs="*")
+	args = parser.parse_args(argv)
 
+	exceptions = get_mismatched_versions()
 	if exceptions:
 		for exception in exceptions:
 			for package, apps in exception.items():
 				print(f"\nVersion mismatch for {package} in:")
 				for app, version in apps.items():
 					print(f"{app}: {version}")
-
-		sys.exit(1) if all(exceptions) else sys.exit(0)
+		sys.exit(1)

--- a/test_utils/pre_commit/validate_python_dependencies.py
+++ b/test_utils/pre_commit/validate_python_dependencies.py
@@ -16,7 +16,11 @@ def get_versions(app):
 	if not pyproject_toml:
 		return {}
 
-	dependencies = pyproject_toml.get("project").get("dependencies", [])
+	if pyproject_toml.get("build-system", {}).get("build-backend") == "flit_core.buildapi":
+		dependencies = pyproject_toml.get("project", {}).get("dependencies", [])
+	elif pyproject_toml.get("build-system", {}).get("build-backend") == "poetry.core.masonry.api":
+		dependencies =pyproject_toml.get("tool", {}).get("poetry", {}).get("dependencies", [])
+
 	dependency_objects = {}
 	for dep in dependencies:
 		if '==' in dep:


### PR DESCRIPTION
Update validate_python_dependencies to work as pre-commit hook
To use this as pre-commit hook - 
```
  - repo: https://github.com/agritheory/test_utils/
    rev: {rev} // The revision or tag to clone. Example: rev: v0.3.0
    hooks:
      - id: validate_python_dependencies
```