### PR TITLE
feat: auto update pre-commit config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -33,3 +33,10 @@
   entry: validate_customizations
   language: python
   require_serial: true
+
+- id: update_pre_commit_config
+  name: update_pre_commit_config
+  description: "Update test_utils pre-commit config to latest"
+  entry: update_pre_commit_config
+  language: python
+  require_serial: true

--- a/docs/pre_commit_hooks.md
+++ b/docs/pre_commit_hooks.md
@@ -62,3 +62,14 @@ Validate Customizations
       - id: validate_customizations
         args: ["--set-module", "True"]
 ```
+
+### Update pre-commit config - `update_pre_commit_config`
+
+Update test_utils pre-commit config to latest
+
+```
+  - repo: https://github.com/agritheory/test_utils/
+    rev: {rev} // The revision or tag to clone. Example: rev: v0.5.0
+    hooks:
+      - id: update_pre_commit_config
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ validate_copyright = "test_utils.pre_commit.validate_copyright:main"
 validate_javascript_dependencies = "test_utils.pre_commit.validate_javascript_dependencies:main"
 validate_python_dependencies = "test_utils.pre_commit.validate_python_dependencies:main"
 validate_customizations = "test_utils.pre_commit.validate_customizations:main"
+update_pre_commit_config = "test_utils.pre_commit.update_pre_commit_config:main"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"

--- a/test_utils/pre_commit/update_pre_commit_config.py
+++ b/test_utils/pre_commit/update_pre_commit_config.py
@@ -1,0 +1,19 @@
+
+import subprocess
+import sys
+
+def main():
+	try:
+		# Run the pre-commit autoupdate with --repo (path to test_utils) to update pre-commit config
+		result = subprocess.run(["pre-commit", "autoupdate", "--repo", "https://github.com/agritheory/test_utils"], capture_output=True, text=True)
+
+		print(result.stdout)
+		if result.stderr:
+			print(result.stderr)
+
+	except Exception as e:
+		print(f"Error: {e}")
+		sys.exit(1)
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
closes #19 
To use this as pre-commit hook - 
```
  - repo: https://github.com/agritheory/test_utils/
    rev: {rev} // The revision or tag to clone. Example: rev: v0.11.0
    hooks:
      - id: update_pre_commit_config
```
Result - 
![image](https://github.com/agritheory/test_utils/assets/53251406/23fdcb5d-2e03-4e6a-bfeb-0c3d0e0af497)
