### PR TITLE
feat: create partition helper

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 from test_utils.utils.conftest import db_instance, monkeymodule
 from test_utils.utils.customize import add_customization_hash, load_customizations
+from test_utils.utils.create_partition import create_partition
 
 __version__ = "0.13.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ validate_javascript_dependencies = "test_utils.pre_commit.validate_javascript_de
 validate_python_dependencies = "test_utils.pre_commit.validate_python_dependencies:main"
 validate_customizations = "test_utils.pre_commit.validate_customizations:main"
 update_pre_commit_config = "test_utils.pre_commit.update_pre_commit_config:main"
+create_partition = "test_utils.utils.create_partition:create_partition"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -183,14 +183,6 @@ def create_partition():
 			)
 			partition_sql += ",\n".join(partitions)
 			partition_sql += ");"
-
-			try:
-				frappe.db.sql(partition_sql)
-				frappe.db.commit()
-				print(f"Partitioning for {doctype} completed successfully.")
-			except Exception as e:
-				print(f"Error while partitioning {doctype}: {e}")
-
 		else:
 			partitions = []
 			for fiscal_year in fiscal_years:
@@ -245,9 +237,10 @@ def create_partition():
 
 			partition_sql += ",\n".join(partitions)
 			partition_sql += ");"
-			try:
-				frappe.db.sql(partition_sql)
-				frappe.db.commit()
-				print(f"Partitioning for {doctype} completed successfully.")
-			except Exception as e:
-				print(f"Error while partitioning {doctype}: {e}")
+
+		try:
+			frappe.db.sql(partition_sql)
+			frappe.db.commit()
+			print(f"Partitioning for {doctype} completed successfully.")
+		except Exception as e:
+			print(f"Error while partitioning {doctype}: {e}")

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -1,0 +1,36 @@
+try:
+	import frappe
+except Exception as e:
+	raise (e)
+
+
+def create_partition():
+	# eg. partition_doctypes = ["Customer", "Item", "Sales Order"]
+	partition_doctypes = frappe.get_hooks("partition_doctypes")
+
+	fiscal_years = frappe.get_all(
+		"Fiscal Year", fields=["name", "year_start_date", "year_end_date"]
+	)
+
+	for doctype in partition_doctypes:
+		partition_based_on = "modified"
+
+		partition_sql = (
+			f"ALTER TABLE `tab{doctype}` PARTITION BY RANGE (YEAR({partition_based_on})) ("
+		)
+
+		for year in fiscal_years:
+			year_start = year.get("year_start_date").year
+			year_end = year.get("year_end_date").year + 1
+			partition_sql += (
+				f"PARTITION fiscal_year_{year_start} VALUES LESS THAN ({year_end}), "
+			)
+
+		partition_sql = partition_sql.rstrip(", ") + ");"
+
+		try:
+			frappe.db.sql(partition_sql)
+			frappe.db.commit()
+			print(f"Partitioning for {doctype} completed successfully.")
+		except Exception as e:
+			print(f"Error while partitioning {doctype}: {e}")

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -7,12 +7,14 @@ except Exception as e:
 
 def primary_key_exists(table_name):
 	try:
-		result = frappe.db.sql(f"""
-		SELECT COUNT(*) 
+		result = frappe.db.sql(
+			f"""
+		SELECT COUNT(*)
 		FROM information_schema.TABLE_CONSTRAINTS
-		WHERE TABLE_NAME = '{table_name}' 
+		WHERE TABLE_NAME = '{table_name}'
 		AND CONSTRAINT_TYPE = 'PRIMARY KEY';
-		""")
+		"""
+		)
 		return result[0][0] > 0
 	except Exception as e:
 		print(f"Error checking primary key existence: {e}")
@@ -27,8 +29,8 @@ def modify_primary_key(table_name, date_field):
 			DROP PRIMARY KEY;
 			"""
 			frappe.db.sql(drop_pk_sql)
-			
-			pk_columns =  f"name, {date_field}"
+
+			pk_columns = f"name, {date_field}"
 			add_pk_sql = f"""
 			ALTER TABLE `{table_name}`
 			ADD PRIMARY KEY ({pk_columns});
@@ -43,17 +45,18 @@ def modify_primary_key(table_name, date_field):
 def create_partition():
 	"""
 	partition_doctypes = {
-		"Sales Order": {
-			"date_field": "transaction_date",
-		},
-		"Sales Invoice": {
-			"date_field": "posting_date",
-		},
+	        "Sales Order": {
+	                "date_field": "transaction_date",
+	        },
+	        "Sales Invoice": {
+	                "date_field": "posting_date",
+	        },
 	"""
 	partition_doctypes = frappe.get_hooks("partition_doctypes")
-
 	fiscal_years = frappe.get_all(
-		"Fiscal Year", fields=["name", "year_start_date", "year_end_date"], order_by="year_start_date ASC"
+		"Fiscal Year",
+		fields=["name", "year_start_date", "year_end_date"],
+		order_by="year_start_date ASC",
 	)
 
 	for doctype, settings in partition_doctypes.items():

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -1,22 +1,68 @@
 try:
 	import frappe
+	from frappe.utils import get_table_name
 except Exception as e:
 	raise (e)
 
 
+def primary_key_exists(table_name):
+    try:
+        result = frappe.db.sql(f"""
+        SELECT COUNT(*) 
+        FROM information_schema.TABLE_CONSTRAINTS
+        WHERE TABLE_NAME = '{table_name}' 
+        AND CONSTRAINT_TYPE = 'PRIMARY KEY';
+        """)
+        return result[0][0] > 0
+    except Exception as e:
+        print(f"Error checking primary key existence: {e}")
+        return False
+
+
+def modify_primary_key(table_name, date_field):
+	try:
+		if primary_key_exists(table_name):
+			drop_pk_sql = f"""
+			ALTER TABLE `{table_name}`
+			DROP PRIMARY KEY;
+			"""
+			frappe.db.sql(drop_pk_sql)
+			
+			pk_columns =  f"name, {date_field}"
+			add_pk_sql = f"""
+			ALTER TABLE `{table_name}`
+			ADD PRIMARY KEY ({pk_columns});
+			"""
+			frappe.db.sql(add_pk_sql)
+			frappe.db.commit()
+			print(f"Primary key modified in table {table_name} to include columns: {pk_columns}")
+	except Exception as e:
+		print(f"Error modifying primary key: {e}")
+
+
 def create_partition():
-	# eg. partition_doctypes = ["Customer", "Item", "Sales Order"]
+	"""
+	partition_doctypes = {
+		"Sales Order": {
+			"date_field": "transaction_date",
+		},
+		"Sales Invoice": {
+			"date_field": "posting_date",
+		},
+	"""
 	partition_doctypes = frappe.get_hooks("partition_doctypes")
 
 	fiscal_years = frappe.get_all(
-		"Fiscal Year", fields=["name", "year_start_date", "year_end_date"]
+		"Fiscal Year", fields=["name", "year_start_date", "year_end_date"], order_by="year_start_date ASC"
 	)
 
-	for doctype in partition_doctypes:
-		partition_based_on = "modified"
+	for doctype, settings in partition_doctypes.items():
+		table_name = get_table_name(doctype)
+		date_field = settings["date_field"][0]
+		modify_primary_key(table_name, date_field)
 
 		partition_sql = (
-			f"ALTER TABLE `tab{doctype}` PARTITION BY RANGE (YEAR({partition_based_on})) ("
+			f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR({date_field})) ("
 		)
 
 		for year in fiscal_years:

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -5,6 +5,65 @@ except Exception as e:
 	raise (e)
 
 
+def add_custom_field(parent_doctype, partition_field):
+	parent_doctype_meta = frappe.get_meta(parent_doctype)
+	partition_docfield = parent_doctype_meta._fields.get(partition_field)
+
+	for child_doctype in [df.options for df in parent_doctype_meta.get_table_fields()]:
+
+		if frappe.get_all(
+			"Custom Field", filters={"dt": child_doctype, "fieldname": partition_field}
+		):
+			return
+
+		custom_field = frappe.get_doc(
+			{
+				"doctype": "Custom Field",
+				"dt": child_doctype,
+				"fieldname": partition_docfield.fieldname,
+				"fieldtype": partition_docfield.fieldtype,
+				"label": partition_docfield.label,
+				"options": partition_docfield.options,
+				"default": partition_docfield.default,
+				"read_only": 1,
+				"hidden": 1,
+			}
+		)
+		try:
+			custom_field.insert()
+		except Exception:
+			continue
+
+
+def populate_partition_fields(doc, event):
+	"""
+	doc_events = {
+	        "*": {
+	                "before_insert": "yourapp.utils.populate_partition_fields",
+	                "before_save": "yourapp.utils.populate_partition_fields",
+	        }
+	}
+	"""
+	partition_doctypes = frappe.get_hooks("partition_doctypes")
+
+	if doc.doctype not in partition_doctypes.keys():
+		return
+
+	partition_field = partition_doctypes[doc.doctype]["field"][0]
+
+	for child_doctype_fieldname in [
+		(df.options, df.fieldname) for df in frappe.get_meta(doc.doctype).get_table_fields()
+	]:
+		child_doctype = child_doctype_fieldname[0]
+		child_fieldname = child_doctype_fieldname[1]
+
+		if not frappe.get_meta(child_doctype)._fields.get(partition_field):
+			add_custom_field(doc.doctype, partition_field)
+
+		for row in getattr(doc, child_fieldname):
+			setattr(row, partition_field, doc.get(partition_field))
+
+
 def primary_key_exists(table_name):
 	try:
 		result = frappe.db.sql(
@@ -53,89 +112,142 @@ def modify_primary_key(table_name, partition_field):
 			frappe.db.commit()
 			print(f"Primary key modified in table {table_name} to include columns: {pk_columns}")
 	except Exception as e:
-		print(f"Error modifying primary key: {e}")
+		print(f"Error modifying primary key in table {table_name}: {e}")
+
+
+def get_partition_doctypes_extended():
+	partition_doctypes = frappe.get_hooks("partition_doctypes")
+	partition_doctypes_extended = {}
+
+	for doctype, settings in partition_doctypes.items():
+		partition_doctypes_extended[doctype] = settings
+		for child_doctype in [
+			df.options for df in frappe.get_meta(doctype).get_table_fields()
+		]:
+			partition_doctypes_extended[child_doctype] = settings
+
+	return partition_doctypes_extended
 
 
 def create_partition():
 	"""
 	partition_doctypes = {
-	        "Sales Order": {
-	                "field": "transaction_date",
-	                "partition_by": "fiscal_year",  # Options: "fiscal_year", "quarter", "month", "field"
-	        },
-	        "Sales Invoice": {
-	                "field": "posting_date",
-	                "partition_by": "fiscal_year",  # Options: "fiscal_year", "quarter", "month", "field"
-	        },
-	        "Item": {
-	                "field": "disabled",
-	                "partition_by": "field",  # Options: "fiscal_year", "quarter", "month", "field"
-	        },
+	                "Sales Order": {
+	                                "field": "transaction_date",
+	                                "partition_by": "fiscal_year",  # Options: "fiscal_year", "quarter", "month", "field"
+	                },
+	                "Sales Invoice": {
+	                                "field": "posting_date",
+	                                "partition_by": "fiscal_year",  # Options: "fiscal_year", "quarter", "month", "field"
+	                },
+	                "Item": {
+	                                "field": "disabled",
+	                                "partition_by": "field",  # Options: "fiscal_year", "quarter", "month", "field"
+	                },
 	"""
 	partition_doctypes = frappe.get_hooks("partition_doctypes")
+
 	fiscal_years = frappe.get_all(
 		"Fiscal Year",
 		fields=["name", "year_start_date", "year_end_date"],
 		order_by="year_start_date ASC",
 	)
 
+	# Creates the field for child doctypes if it doesn't exists yet
 	for doctype, settings in partition_doctypes.items():
+		add_custom_field(doctype, settings.get("field", "posting_date")[0])
+
+	for doctype, settings in get_partition_doctypes_extended().items():
 		table_name = get_table_name(doctype)
 		partition_field = settings.get("field", "posting_date")[0]
 		partition_by = settings.get("partition_by", "fiscal_year")[0]
 
 		modify_primary_key(table_name, partition_field)
 
-		partitions = []
+		if partition_by == "field":
+			partitions = []
+			partition_values = frappe.db.sql(
+				f"SELECT DISTINCT `{partition_field}` FROM `{table_name}`", as_dict=True
+			)
+			for value in partition_values:
+				partition_value = value[partition_field]
+				partition_name = f"{partition_field}_{partition_value}"
+				if partition_name not in [p.split()[1] for p in partitions]:
+					partitions.append(f"PARTITION {partition_name} VALUES IN ({partition_value})")
 
-		for fiscal_year in fiscal_years:
-			year_start = fiscal_year.get("year_start_date").year
-			year_end = fiscal_year.get("year_end_date").year + 1
+			if not partitions:
+				continue
 
-			if partition_by == "fiscal_year":
-				partition_sql = (
-					f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR(`{partition_field}`)) (\n"
-				)
-				for fiscal_year in fiscal_years:
-					partitions.append(
-						f"PARTITION fiscal_year_{year_start} VALUES LESS THAN ({year_end}), "
+			partition_sql = (
+				f"ALTER TABLE `{table_name}` PARTITION BY LIST (`{partition_field}`) (\n"
+			)
+			partition_sql += ",\n".join(partitions)
+			partition_sql += ");"
+
+			try:
+				frappe.db.sql(partition_sql)
+				frappe.db.commit()
+				print(f"Partitioning for {doctype} completed successfully.")
+			except Exception as e:
+				print(f"Error while partitioning {doctype}: {e}")
+
+		else:
+			partitions = []
+			for fiscal_year in fiscal_years:
+				year_start = fiscal_year.get("year_start_date").year
+				year_end = fiscal_year.get("year_end_date").year + 1
+
+				if partition_by == "fiscal_year":
+					partition_sql = (
+						f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR(`{partition_field}`)) (\n"
 					)
+					for fiscal_year in fiscal_years:
+						partitions.append(
+							f"PARTITION fiscal_year_{year_start} VALUES LESS THAN ({year_end}), "
+						)
 
-			elif partition_by == "quarter":
-				partition_sql = f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR(`{partition_field}`) * 10 + QUARTER(`{partition_field}`)) (\n"
-				for quarter in range(1, 5):
-					quarter_code = year_start * 10 + quarter
-					partitions.append(
-						f"PARTITION {year_start}_quarter_{quarter} VALUES LESS THAN ({quarter_code + 1})"
+				elif partition_by == "quarter":
+					partition_sql = f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR(`{partition_field}`) * 10 + QUARTER(`{partition_field}`)) (\n"
+					for quarter in range(1, 5):
+						quarter_code = year_start * 10 + quarter
+						partitions.append(
+							f"PARTITION {year_start}_quarter_{quarter} VALUES LESS THAN ({quarter_code + 1})"
+						)
+
+				elif partition_by == "month":
+					partition_sql = f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR(`{partition_field}`) * 100 + MONTH(`{partition_field}`)) (\n"
+					for month in range(1, 13):
+						month_code = year_start * 100 + month
+						partitions.append(
+							f"PARTITION {year_start}_month_{month:02d} VALUES LESS THAN ({month_code + 1})"
+						)
+
+				elif partition_by == "field":
+					field_partitions = []
+					partition_values = frappe.db.sql(
+						f"SELECT DISTINCT `{partition_field}` FROM `{table_name}`", as_dict=True
 					)
+					for value in partition_values:
+						partition_value = value[partition_field]
+						partition_name = f"{partition_field}_{partition_value}"
+						if partition_name not in [p.split()[1] for p in partitions]:
+							field_partitions.append(
+								f"PARTITION {partition_name} VALUES IN ({partition_value})"
+							)
 
-			elif partition_by == "month":
-				partition_sql = f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR(`{partition_field}`) * 100 + MONTH(`{partition_field}`)) (\n"
-				for month in range(1, 13):
-					month_code = year_start * 100 + month
-					partitions.append(
-						f"PARTITION {year_start}_month_{month:02d} VALUES LESS THAN ({month_code + 1})"
+					if not field_partitions:
+						continue
+
+					partition_sql = (
+						f"ALTER TABLE `{table_name}` PARTITION BY LIST (`{partition_field}`) (\n"
 					)
+					partitions += field_partitions
 
-			elif partition_by == "field":
-				partition_sql = (
-					f"ALTER TABLE `{table_name}` PARTITION BY LIST (`{partition_field}`) (\n"
-				)
-				partition_values = frappe.db.sql(
-					f"SELECT DISTINCT `{partition_field}` FROM `{table_name}`", as_dict=True
-				)
-				for value in partition_values:
-					partition_value = value[partition_field]
-					partition_name = f"{partition_field}_{partition_value}"
-					if partition_name not in [p.split()[1] for p in partitions]:
-						partitions.append(f"PARTITION {partition_name} VALUES IN ({partition_value})")
-
-		partition_sql += ",\n".join(partitions)
-		partition_sql += ");"
-
-		try:
-			frappe.db.sql(partition_sql)
-			frappe.db.commit()
-			print(f"Partitioning for {doctype} completed successfully.")
-		except Exception as e:
-			print(f"Error while partitioning {doctype}: {e}")
+			partition_sql += ",\n".join(partitions)
+			partition_sql += ");"
+			try:
+				frappe.db.sql(partition_sql)
+				frappe.db.commit()
+				print(f"Partitioning for {doctype} completed successfully.")
+			except Exception as e:
+				print(f"Error while partitioning {doctype}: {e}")

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -6,17 +6,17 @@ except Exception as e:
 
 
 def primary_key_exists(table_name):
-    try:
-        result = frappe.db.sql(f"""
-        SELECT COUNT(*) 
-        FROM information_schema.TABLE_CONSTRAINTS
-        WHERE TABLE_NAME = '{table_name}' 
-        AND CONSTRAINT_TYPE = 'PRIMARY KEY';
-        """)
-        return result[0][0] > 0
-    except Exception as e:
-        print(f"Error checking primary key existence: {e}")
-        return False
+	try:
+		result = frappe.db.sql(f"""
+		SELECT COUNT(*) 
+		FROM information_schema.TABLE_CONSTRAINTS
+		WHERE TABLE_NAME = '{table_name}' 
+		AND CONSTRAINT_TYPE = 'PRIMARY KEY';
+		""")
+		return result[0][0] > 0
+	except Exception as e:
+		print(f"Error checking primary key existence: {e}")
+		return False
 
 
 def modify_primary_key(table_name, date_field):

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -6,6 +6,9 @@ except Exception as e:
 
 
 def add_custom_field(parent_doctype, partition_field):
+	# Skip creation of standard fields
+	if partition_field in frappe.model.default_fields:
+		return
 	parent_doctype_meta = frappe.get_meta(parent_doctype)
 	partition_docfield = parent_doctype_meta._fields.get(partition_field)
 	if not partition_docfield:
@@ -41,7 +44,8 @@ def add_custom_field(parent_doctype, partition_field):
 		)
 		try:
 			custom_field.insert()
-		except Exception:
+		except Exception as e:
+			print(f"Error adding {partition_field} to {child_doctype} for {parent_doctype}: {e}")
 			continue
 
 

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -23,11 +23,10 @@ def add_custom_field(parent_doctype, partition_field):
 		)
 
 	for child_doctype in [df.options for df in parent_doctype_meta.get_table_fields()]:
-
 		if frappe.get_all(
 			"Custom Field", filters={"dt": child_doctype, "fieldname": partition_field}
 		):
-			return
+			continue
 		print(f"Adding {partition_field} to {child_doctype} for {parent_doctype}")
 		custom_field = frappe.get_doc(
 			{

--- a/test_utils/utils/mysqldump_wrapper.sh
+++ b/test_utils/utils/mysqldump_wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+DB_USER=$1
+DB_PASS=$2
+DB_HOST=$3
+DB_NAME=$4
+OUTPUT_FILE=$5
+shift 5
+IGNORE_TABLES=("$@")
+
+CMD="mysqldump -u $DB_USER -p$DB_PASS -h $DB_HOST $DB_NAME --no-create-db --routines --triggers --events --single-transaction"
+
+for TABLE in "${IGNORE_TABLES[@]}"; do
+    CMD="$CMD --ignore-table=\"$DB_NAME.$TABLE\""
+done
+
+CMD="$CMD > $OUTPUT_FILE"
+
+eval $CMD

--- a/test_utils/utils/restore_partitions.py
+++ b/test_utils/utils/restore_partitions.py
@@ -329,6 +329,17 @@ def get_site_config_data(site_name):
 		return None
 
 
+def delete_backup_files(backup_dir):
+	try:
+		for filename in os.listdir(backup_dir):
+			file_path = os.path.join(backup_dir, filename)
+			if any(filename.endswith(ext) for ext in [".sql", ".gz", ".csv"]):
+				os.remove(file_path)
+				print(f"Deleted file: {file_path}")
+	except Exception as e:
+		print(f"Error while deleting backup files: {str(e)}")
+
+
 def restore(
 	from_site,
 	to_site,
@@ -339,6 +350,7 @@ def restore(
 	partitioned_doctypes_to_restore=None,
 	last_n_partitions=1,
 	compress=False,
+	delete_files=False,
 ):
 	from_site_config = get_site_config_data(from_site)
 	to_site_config = get_site_config_data(to_site)
@@ -373,3 +385,5 @@ def restore(
 		partitioned_doctypes_to_restore,
 		last_n_partitions,
 	)
+	if delete_files:
+		delete_backup_files(backup_dir)

--- a/test_utils/utils/restore_partitions.py
+++ b/test_utils/utils/restore_partitions.py
@@ -8,6 +8,7 @@ import csv
 import gzip
 import shutil
 import json
+import sys
 import frappe
 
 
@@ -252,6 +253,8 @@ def backup_partition(site, table, current_partition, compress):
 
 
 def restore_partition(site, table, partition_bkp_file):
+
+	csv.field_size_limit(sys.maxsize)
 	try:
 		partition_bkp_file = uncompress_if_needed(partition_bkp_file)
 		connection = pymysql.connect(

--- a/test_utils/utils/restore_partitions.py
+++ b/test_utils/utils/restore_partitions.py
@@ -1,0 +1,249 @@
+import subprocess
+import datetime
+import shlex
+import frappe
+import pymysql
+import os
+import importlib.resources
+
+
+def get_child_doctypes(doctype):
+	doctype_meta = frappe.get_meta(doctype)
+	return [df.options for df in doctype_meta.get_table_fields()]
+
+
+def get_partitioned_tables():
+	partitioned_tables = []
+	partition_doctypes = frappe.get_hooks("partition_doctypes")
+	for doctype in partition_doctypes.keys():
+		partitioned_tables.append(f"tab{doctype}")
+		for child_doctype in get_child_doctypes(doctype):
+			partitioned_tables.append(f"tab{child_doctype}")
+	return list(set(partitioned_tables))
+
+
+def dump_schema_only(site, schema_dump_file):
+	exclude_tables = get_partitioned_tables()
+	try:
+		command = (
+			f"mysqldump -u {site['user']} -p{site['password']} -h {site['host']} {site['db']} "
+			f"--no-data " + " ".join([shlex.quote(table) for table in exclude_tables])
+		)
+		with open(schema_dump_file, "w") as f:
+			subprocess.run(
+				command, shell=True, stdout=f, stderr=subprocess.PIPE, text=True, check=True
+			)
+		print(f"Schema dump completed successfully. File saved as {schema_dump_file}.")
+		return schema_dump_file
+	except subprocess.CalledProcessError as e:
+		print(f"Error during schema dump: {e.stderr}")
+	except Exception as e:
+		print(f"Unexpected error: {e}")
+
+
+def backup_full_database(site, full_backup_file):
+	exclude_tables = get_partitioned_tables()  # Fetch list of tables to exclude
+
+	try:
+		# Locate the shell script within the module
+		with importlib.resources.path(
+			"test_utils.utils", "mysqldump_wrapper.sh"
+		) as script_path:
+			# Copy the script to a temporary location
+			temp_script_path = "/tmp/mysqldump_wrapper.sh"
+			with open(script_path) as src_file:
+				with open(temp_script_path, "w") as temp_file:
+					temp_file.write(src_file.read())
+
+			# Make the temporary script executable
+			os.chmod(temp_script_path, 0o755)
+
+			# Prepare the command and arguments for the wrapper script
+			command = [
+				temp_script_path,
+				site["user"],
+				site["password"],
+				site["host"],
+				site["db"],
+				full_backup_file,
+			] + exclude_tables
+
+			# Execute the wrapper script
+			print("Executing command:", " ".join(command))  # Debug output
+
+			result = subprocess.run(command, capture_output=True, text=True, check=False)
+
+			# Check for errors
+			if result.returncode != 0:
+				print(f"Error occurred: {result.stderr}")
+				raise Exception(f"Backup failed with return code {result.returncode}")
+
+			return full_backup_file
+	except Exception as e:
+		print(f"Unexpected error: {e}")
+
+
+def merge_sql_files(
+	schema_dump_path,
+	full_backup_path,
+	output_path="/tmp/schema_and_non_partitioned_data.sql",
+):
+	try:
+		# Construct the cat command
+		command = [
+			"bash",
+			"-c",
+			f'cat "{schema_dump_path}" "{full_backup_path}" > "{output_path}"',
+		]
+
+		# Execute the command
+		result = subprocess.run(command, capture_output=True, text=True, check=False)
+
+		# Check for errors
+		if result.returncode != 0:
+			print(f"Error occurred: {result.stderr}")
+			raise Exception(f"Merge failed with return code {result.returncode}")
+
+		print(f"Files merged successfully into {output_path}")
+		return output_path
+
+	except Exception as e:
+		print(f"An error occurred: {e}")
+
+
+def restore_database(site, backup_file):
+	try:
+		command = [
+			"bench",
+			"--site",
+			site["name"],
+			"restore",
+			backup_file,
+			"--db-root-password",
+			site["password"],
+		]
+		result = subprocess.run(command, capture_output=True, text=True, check=False)
+
+		if result.returncode != 0:
+			print(f"Error occurred: {result.stderr}")
+			raise Exception(f"Restore failed with return code {result.returncode}")
+
+		print("Restore completed successfully.")
+	except Exception as e:
+		print(f"Unexpected error: {e}")
+
+
+def get_partitions_to_backup(tables_partitions):
+	partitions_to_backup = {}
+	for doctype, partitions in tables_partitions.items():
+		partitions_to_backup[f"tab{doctype}"] = partitions
+		for child_doctype in get_child_doctypes(doctype):
+			partitions_to_backup[f"tab{child_doctype}"] = partitions
+	return partitions_to_backup
+
+
+def backup_partition(site, table, current_partition):
+	timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+	output_file = (
+		f'/tmp/{table.lower().replace(" ", "")}_{current_partition}_{timestamp}.sql'
+	)
+
+	sql_query = f"""
+    SELECT * FROM `{table}` PARTITION ({current_partition})
+    INTO OUTFILE '{output_file}'
+    FIELDS TERMINATED BY ','
+    ENCLOSED BY '"'
+    LINES TERMINATED BY '\n';
+    """
+
+	try:
+		connection = pymysql.connect(
+			user=site["user"], password=site["password"], host=site["host"], database=site["db"]
+		)
+		cursor = connection.cursor()
+		cursor.execute(sql_query)
+		connection.commit()
+		cursor.close()
+		connection.close()
+		print(
+			f"Backup of partition {current_partition} completed successfully. File saved as {output_file}."
+		)
+		return output_file
+	except pymysql.MySQLError as e:
+		print(f"Error during backup: {e}")
+		return None
+	except Exception as e:
+		print(f"Unexpected error: {e}")
+		return None
+
+
+def restore_partition(site, table, partition_bkp_file):
+	try:
+		connection = pymysql.connect(
+			user=site["user"], password=site["password"], host=site["host"], database=site["db"]
+		)
+		cursor = connection.cursor()
+		sql_query = f"""
+        LOAD DATA INFILE '{partition_bkp_file}'
+        INTO TABLE `{table}`
+        FIELDS TERMINATED BY ','
+        ENCLOSED BY '"'
+        LINES TERMINATED BY '\\n'
+        IGNORE 1 LINES;
+        """
+		cursor.execute(sql_query)
+		connection.commit()
+		cursor.close()
+		connection.close()
+		print(f"Data imported successfully from {partition_bkp_file}.")
+	except pymysql.MySQLError as e:
+		print(f"Error during import: {e}")
+	except Exception as e:
+		print(f"Unexpected error: {e}")
+
+
+"""
+from_site = {
+    "user": "root",
+    "password": "123",
+    "host": "172.18.0.2",
+    "db": "_9f2612621965ef9a",
+    "name": "partition.localhost",
+}
+
+to_site = {
+    "user": "root",
+    "password": "123",
+    "host": "172.18.0.2",
+    "db": "partitionrestore.localhost",
+    "name": "partitionrestore.localhost",
+}
+
+tables_partitions = {
+    'Sales Order': ['2018_month_01', '2018_month_02'],
+    'Sales Invoice': ['2018_month_01', '2018_month_02'],
+}
+
+"""
+
+
+def restore(from_site, to_site, tables_partitions):
+	schema_dump_file = dump_schema_only(from_site, "/tmp/schema_dump.sql")
+	full_bkp_file = backup_full_database(from_site, "/tmp/full_backup_file.sql")
+	schema_and_non_partitioned_data = merge_sql_files(
+		schema_dump_file,
+		full_bkp_file,
+		output_path="/tmp/schema_and_non_partitioned_data.sql",
+	)
+	restore_database(to_site, schema_and_non_partitioned_data)
+
+	partitions_to_backup = get_partitions_to_backup(tables_partitions)
+
+	bkps_files = []
+	for table, partitions in partitions_to_backup.items():
+		for partition in partitions:
+			partition_bkp_file = backup_partition(from_site, table, partition)
+			bkps_files.append({"table": table, "partition_bkp_file": partition_bkp_file})
+
+	for file in bkps_files:
+		restore_partition(to_site, file["table"], file["partition_bkp_file"])

--- a/test_utils/utils/restore_partitions.py
+++ b/test_utils/utils/restore_partitions.py
@@ -42,23 +42,19 @@ def dump_schema_only(site, schema_dump_file):
 
 
 def backup_full_database(site, full_backup_file):
-	exclude_tables = get_partitioned_tables()  # Fetch list of tables to exclude
+	exclude_tables = get_partitioned_tables()
 
 	try:
-		# Locate the shell script within the module
 		with importlib.resources.path(
 			"test_utils.utils", "mysqldump_wrapper.sh"
 		) as script_path:
-			# Copy the script to a temporary location
 			temp_script_path = "/tmp/mysqldump_wrapper.sh"
 			with open(script_path) as src_file:
 				with open(temp_script_path, "w") as temp_file:
 					temp_file.write(src_file.read())
 
-			# Make the temporary script executable
 			os.chmod(temp_script_path, 0o755)
 
-			# Prepare the command and arguments for the wrapper script
 			command = [
 				temp_script_path,
 				site["user"],
@@ -68,12 +64,8 @@ def backup_full_database(site, full_backup_file):
 				full_backup_file,
 			] + exclude_tables
 
-			# Execute the wrapper script
-			print("Executing command:", " ".join(command))  # Debug output
-
 			result = subprocess.run(command, capture_output=True, text=True, check=False)
 
-			# Check for errors
 			if result.returncode != 0:
 				print(f"Error occurred: {result.stderr}")
 				raise Exception(f"Backup failed with return code {result.returncode}")
@@ -89,24 +81,18 @@ def merge_sql_files(
 	output_path="/tmp/schema_and_non_partitioned_data.sql",
 ):
 	try:
-		# Construct the cat command
 		command = [
 			"bash",
 			"-c",
 			f'cat "{schema_dump_path}" "{full_backup_path}" > "{output_path}"',
 		]
-
-		# Execute the command
 		result = subprocess.run(command, capture_output=True, text=True, check=False)
-
-		# Check for errors
 		if result.returncode != 0:
 			print(f"Error occurred: {result.stderr}")
 			raise Exception(f"Merge failed with return code {result.returncode}")
 
 		print(f"Files merged successfully into {output_path}")
 		return output_path
-
 	except Exception as e:
 		print(f"An error occurred: {e}")
 
@@ -206,24 +192,23 @@ def restore_partition(site, table, partition_bkp_file):
 from_site = {
     "user": "root",
     "password": "123",
-    "host": "172.18.0.2",
-    "db": "_9f2612621965ef9a",
-    "name": "partition.localhost",
+    "host": "localhost,
+    "db": "db_name",
+    "name": "site_name",
 }
 
 to_site = {
     "user": "root",
     "password": "123",
-    "host": "172.18.0.2",
-    "db": "partitionrestore.localhost",
-    "name": "partitionrestore.localhost",
+    "host": "localhost,
+    "db": "db_name",
+    "name": "site_name",
 }
 
 tables_partitions = {
     'Sales Order': ['2018_month_01', '2018_month_02'],
     'Sales Invoice': ['2018_month_01', '2018_month_02'],
 }
-
 """
 
 


### PR DESCRIPTION
Issue #74 

### Hooks
```python

# Tables to be ignored in the full backup
exclude_tables = ["__global_search", "tabAccess Log", "tabActivity Log"]

# Doctypes to be partitioned
partition_doctypes = {
    "Sales Order": {
        "field": "transaction_date",
        "partition_by": "month",  # Options: "fiscal_year", "quarter", "month"
    },
    "Sales Invoice": {
        "field": "posting_date",
        "partition_by": "month",  # Options: "fiscal_year", "quarter", "month"
    },
}
```

### Create partitions
```python
from test_utils.utils.create_partitions import create_partition
create_partition()
```

### Restore
```python
from test_utils.utils.restore_partitions import restore
restore(
	from_site,
	to_site,
	mariadb_user,
	mariadb_password,
	mariadb_host="localhost",
	backup_dir="/tmp",
	partitioned_doctypes_to_restore=None,
	last_n_partitions=1,
	compress=False,
        delete_files=False
)
```


