### PR TITLE
Partitioning Improvements

### DIFF
--- a/docs/partitions.md
+++ b/docs/partitions.md
@@ -71,10 +71,10 @@ bench --site XXX console
 from test_utils.utils.restore_partitions import restore
 
 restore(
-	from_site="ultrapro.agritheory.com",
+	from_site="demo.agritheory.com",
     mariadb_user="root",
 	mariadb_password="123",
-	to_site="upro-m.agritheory.com",
+	to_site="demo2.agritheory.com",
 	to_database=None,
 	mariadb_host="localhost",
 	backup_dir="/tmp",

--- a/docs/partitions.md
+++ b/docs/partitions.md
@@ -4,7 +4,7 @@
 
 #### Partition DocTypes - `partition_doctypes`
 
-Defines the Tables to be partitioned and the criteria.
+The `partition_doctypes` hook defines the tables (DocTypes) that will be partitioned and specifies the criteria for partitioning. Below is an example configuration:
 
 ```python
 partition_doctypes = {
@@ -25,7 +25,7 @@ partition_doctypes = {
 
 #### Exclude Tables - `exclude_tables`
 
-Defines the tables to be ignored in the full database backup.
+The `exclude_tables` hook specifies the tables that should be ignored during a full database backup. For example:
 
 ```python
 exclude_tables = ["__global_search", "tabAccess Log", "tabActivity Log", "tabData Import"]
@@ -34,17 +34,22 @@ exclude_tables = ["__global_search", "tabAccess Log", "tabActivity Log", "tabDat
 
 ## Create Partition
 
-Uses the `partition_doctypes` hook
+The **Create Partition** utility uses the `partition_doctypes` hook to perform several actions:
 
-- Adds custom fields for child tables.
-- Modifies primary keys.
-- Creates the partitions.
+- **Add Custom Fields:** Introduces custom fields for child tables.
+- **Modify Primary Keys:** Adjusts primary keys to support partitioning.
+- **Populates Custom Fields:** Populates custom fields from child tables with existing data.
+- **Create Partitions:** Sets up the defined partitions based on the configuration.
 
 ### Usage
 
+1. Open the bench console for your target site:
+
 ```bash
-bench --site XXX console
+bench --site your_site_name console
 ```
+
+2. Run the partition creation function:
 
 ```python
 from test_utils.utils.create_partition import create_partition
@@ -54,55 +59,85 @@ create_partition()
 
 ## Restore Partition
 
-Restores a database backup from a given Frappe site to another site including the non-partitioned tables and a given number of partitions for the partitioned tables.
+The **Restore Partition** utility facilitates restoring a database backup from one Frappe site to another. It handles both non-partitioned and partitioned tables by performing the following steps:
 
-- Dumps only the full schema of the source database.
-- Does a full backup of the source database excluding partitioned tables.
-- Merges the schema dump and full dump in one file.
-- Restores the previous file into target database.
-- Backup and restore the partitioned data into target database.
+- **Schema Dump:** Dumps the full schema of the source database.
+- **Full Backup:** Creates a full backup of the source database excluding partitioned tables.
+- **Merge Files:** Combines the schema dump and full backup into a single file.
+- **Restore Target:** Restores the merged file into the target database.
+- **Partitioned Data:** Backs up and restores the partitioned data into the target database.
+
 
 ### Usage
+
+1. Open the bench console for the source site:
+
 ```bash
-bench --site XXX console
+bench --site your_source_site console
 ```
+
+2. Execute the restore function:
 
 ```python
 from test_utils.utils.restore_partitions import restore
 
 restore(
-    mariadb_user="root",
-	mariadb_password="123",
-	to_site="demo2.agritheory.com",
-	to_database=None,
-	backup_dir="/tmp",
-	partitioned_doctypes_to_restore=None,  # None tp restore all partitioned doctypes or list of DocTypes to restore ["Sales Order", "Sales Invoice"]
-	last_n_partitions=3,  # Number of partitions to restore
-	compress=False,
-	delete_files=True,
+    mariadb_user="root",                  # MariaDB root username
+    mariadb_password="123",               # MariaDB root password
+    to_site="demo2.agritheory.com",       # Target site URL
+    to_database=None,                     # Optional: specify a target database name (instead a to_site)
+    backup_dir="/tmp",                    # Directory where the backup file will be stored
+    partitioned_doctypes_to_restore=None, # Restore all partitioned doctypes if None, or specify a list (e.g., ["Sales Order", "Sales Invoice"])
+    last_n_partitions=3,                  # Number of partitions to restore per DocType
+    compress=False,                       # Set to True to compress the temporary and backup file
+    delete_files=True,                    # Delete temporary files after the operation
 )
 ```
 
 
 ## Bubble Backup
 
-Creates a database backup for a Frappe site, including all non-partitioned tables and a specified number of partitions for partitioned tables. The backup is saved in the site's /private/backups/ directory.
+The Bubble Backup utility creates a comprehensive backup of a Frappe site's database. It includes:
+
+- **Non-Partitioned Tables:** Full backup of all tables that are not partitioned.
+- **Partitioned Tables:** A specified number of recent partitions for each partitioned table.
+
+The backup is saved in the site's **/private/backups/** directory.
+
+### Configuration 
+
+Before using `bubble_backup`, ensure that your site's `common_site_config.json` contains the necessary database credentials. Specifically, you must define:
+
+- `root_login`: The database root username.
+- `root_password`: The database root password.
+
+You can set these configuration values using the following commands:
+
+```bash
+bench set-config -g root_login root
+bench set-config -g root_password 123
+```
+
+_Replace "root" and "123" with your actual database username and password._
 
 ### Usage
+
+1. Open the bench console for your site:
+
 ```bash
-bench --site XXX console
+bench --site your_site_name console
 ```
+
+2. Run the bubble backup function:
 
 ```python
 from test_utils.utils.restore_partitions import bubble_backup
 
 bubble_backup(
-	mariadb_user="root",
-	mariadb_password="123",
-	backup_dir="/tmp",
-	partitioned_doctypes_to_restore=None,
-	last_n_partitions=1,
-	delete_files=True,
-	keep_temp_db=False,
+    backup_dir="/tmp",                      # Directory where the backup file will be stored
+    partitioned_doctypes_to_restore=None,   # Process all partitioned doctypes if None, or specify a list
+    last_n_partitions=1,                    # Number of most recent partitions to include
+    delete_files=True,                      # Delete temporary files after the backup process
+    keep_temp_db=False,                     # Do not retain the temporary database after the backup
 )
 ```

--- a/docs/partitions.md
+++ b/docs/partitions.md
@@ -54,6 +54,8 @@ create_partition()
 
 ## Restore Partition
 
+Restores a database backup from a given Frappe site to another site including the non-partitioned tables and a given number of partitions for the partitioned tables.
+
 - Dumps only the full schema of the source database.
 - Does a full backup of the source database excluding partitioned tables.
 - Merges the schema dump and full dump in one file.
@@ -70,14 +72,40 @@ from test_utils.utils.restore_partitions import restore
 
 restore(
 	from_site="ultrapro.agritheory.com",
-	to_site="upro-m.agritheory.com",
-	mariadb_user="root",
+    mariadb_user="root",
 	mariadb_password="123",
+	to_site="upro-m.agritheory.com",
+	to_database=None,
 	mariadb_host="localhost",
 	backup_dir="/tmp",
 	partitioned_doctypes_to_restore=None,  # None tp restore all partitioned doctypes or list of DocTypes to restore ["Sales Order", "Sales Invoice"]
 	last_n_partitions=3,  # Number of partitions to restore
 	compress=False,
-	delete_files=False,
+	delete_files=True,
+)
+```
+
+
+## Bubble Backup
+
+Creates a database backup for a Frappe site, including all non-partitioned tables and a specified number of partitions for partitioned tables. The backup is saved in the site's /private/backups/ directory.
+
+### Usage
+```bash
+bench --site XXX console
+```
+
+```python
+from test_utils.utils.restore_partitions import bubble_backup
+
+bubble_backup(
+	mariadb_user="root",
+	mariadb_password="123",
+	mariadb_host="localhost",
+	backup_dir="/tmp",
+	partitioned_doctypes_to_restore=None,
+	last_n_partitions=1,
+	delete_files=True,
+	keep_temp_db=False,
 )
 ```

--- a/docs/partitions.md
+++ b/docs/partitions.md
@@ -71,12 +71,10 @@ bench --site XXX console
 from test_utils.utils.restore_partitions import restore
 
 restore(
-	from_site="demo.agritheory.com",
     mariadb_user="root",
 	mariadb_password="123",
 	to_site="demo2.agritheory.com",
 	to_database=None,
-	mariadb_host="localhost",
 	backup_dir="/tmp",
 	partitioned_doctypes_to_restore=None,  # None tp restore all partitioned doctypes or list of DocTypes to restore ["Sales Order", "Sales Invoice"]
 	last_n_partitions=3,  # Number of partitions to restore
@@ -101,7 +99,6 @@ from test_utils.utils.restore_partitions import bubble_backup
 bubble_backup(
 	mariadb_user="root",
 	mariadb_password="123",
-	mariadb_host="localhost",
 	backup_dir="/tmp",
 	partitioned_doctypes_to_restore=None,
 	last_n_partitions=1,

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,47 +2,53 @@
 
 [[package]]
 name = "mypy"
-version = "1.10.1"
+version = "1.15.0"
 description = "Optional static typing for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "mypy-1.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e36f229acfe250dc660790840916eb49726c928e8ce10fbdf90715090fe4ae02"},
-    {file = "mypy-1.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:51a46974340baaa4145363b9e051812a2446cf583dfaeba124af966fa44593f7"},
-    {file = "mypy-1.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:901c89c2d67bba57aaaca91ccdb659aa3a312de67f23b9dfb059727cce2e2e0a"},
-    {file = "mypy-1.10.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0cd62192a4a32b77ceb31272d9e74d23cd88c8060c34d1d3622db3267679a5d9"},
-    {file = "mypy-1.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:a2cbc68cb9e943ac0814c13e2452d2046c2f2b23ff0278e26599224cf164e78d"},
-    {file = "mypy-1.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bd6f629b67bb43dc0d9211ee98b96d8dabc97b1ad38b9b25f5e4c4d7569a0c6a"},
-    {file = "mypy-1.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1bbb3a6f5ff319d2b9d40b4080d46cd639abe3516d5a62c070cf0114a457d84"},
-    {file = "mypy-1.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8edd4e9bbbc9d7b79502eb9592cab808585516ae1bcc1446eb9122656c6066f"},
-    {file = "mypy-1.10.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6166a88b15f1759f94a46fa474c7b1b05d134b1b61fca627dd7335454cc9aa6b"},
-    {file = "mypy-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:5bb9cd11c01c8606a9d0b83ffa91d0b236a0e91bc4126d9ba9ce62906ada868e"},
-    {file = "mypy-1.10.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d8681909f7b44d0b7b86e653ca152d6dff0eb5eb41694e163c6092124f8246d7"},
-    {file = "mypy-1.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:378c03f53f10bbdd55ca94e46ec3ba255279706a6aacaecac52ad248f98205d3"},
-    {file = "mypy-1.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bacf8f3a3d7d849f40ca6caea5c055122efe70e81480c8328ad29c55c69e93e"},
-    {file = "mypy-1.10.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:701b5f71413f1e9855566a34d6e9d12624e9e0a8818a5704d74d6b0402e66c04"},
-    {file = "mypy-1.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c4c2992f6ea46ff7fce0072642cfb62af7a2484efe69017ed8b095f7b39ef31"},
-    {file = "mypy-1.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:604282c886497645ffb87b8f35a57ec773a4a2721161e709a4422c1636ddde5c"},
-    {file = "mypy-1.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37fd87cab83f09842653f08de066ee68f1182b9b5282e4634cdb4b407266bade"},
-    {file = "mypy-1.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8addf6313777dbb92e9564c5d32ec122bf2c6c39d683ea64de6a1fd98b90fe37"},
-    {file = "mypy-1.10.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5cc3ca0a244eb9a5249c7c583ad9a7e881aa5d7b73c35652296ddcdb33b2b9c7"},
-    {file = "mypy-1.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:1b3a2ffce52cc4dbaeee4df762f20a2905aa171ef157b82192f2e2f368eec05d"},
-    {file = "mypy-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fe85ed6836165d52ae8b88f99527d3d1b2362e0cb90b005409b8bed90e9059b3"},
-    {file = "mypy-1.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c2ae450d60d7d020d67ab440c6e3fae375809988119817214440033f26ddf7bf"},
-    {file = "mypy-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6be84c06e6abd72f960ba9a71561c14137a583093ffcf9bbfaf5e613d63fa531"},
-    {file = "mypy-1.10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2189ff1e39db399f08205e22a797383613ce1cb0cb3b13d8bcf0170e45b96cc3"},
-    {file = "mypy-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:97a131ee36ac37ce9581f4220311247ab6cba896b4395b9c87af0675a13a755f"},
-    {file = "mypy-1.10.1-py3-none-any.whl", hash = "sha256:71d8ac0b906354ebda8ef1673e5fde785936ac1f29ff6987c7483cfbd5a4235a"},
-    {file = "mypy-1.10.1.tar.gz", hash = "sha256:1f8f492d7db9e3593ef42d4f115f04e556130f2819ad33ab84551403e97dd4c0"},
+    {file = "mypy-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:979e4e1a006511dacf628e36fadfecbcc0160a8af6ca7dad2f5025529e082c13"},
+    {file = "mypy-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c4bb0e1bd29f7d34efcccd71cf733580191e9a264a2202b0239da95984c5b559"},
+    {file = "mypy-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be68172e9fd9ad8fb876c6389f16d1c1b5f100ffa779f77b1fb2176fcc9ab95b"},
+    {file = "mypy-1.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7be1e46525adfa0d97681432ee9fcd61a3964c2446795714699a998d193f1a3"},
+    {file = "mypy-1.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2e2c2e6d3593f6451b18588848e66260ff62ccca522dd231cd4dd59b0160668b"},
+    {file = "mypy-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:6983aae8b2f653e098edb77f893f7b6aca69f6cffb19b2cc7443f23cce5f4828"},
+    {file = "mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f"},
+    {file = "mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5"},
+    {file = "mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e"},
+    {file = "mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c"},
+    {file = "mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f"},
+    {file = "mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f"},
+    {file = "mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd"},
+    {file = "mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f"},
+    {file = "mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464"},
+    {file = "mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee"},
+    {file = "mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e"},
+    {file = "mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22"},
+    {file = "mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445"},
+    {file = "mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d"},
+    {file = "mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5"},
+    {file = "mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036"},
+    {file = "mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357"},
+    {file = "mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf"},
+    {file = "mypy-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e601a7fa172c2131bff456bb3ee08a88360760d0d2f8cbd7a75a65497e2df078"},
+    {file = "mypy-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:712e962a6357634fef20412699a3655c610110e01cdaa6180acec7fc9f8513ba"},
+    {file = "mypy-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95579473af29ab73a10bada2f9722856792a36ec5af5399b653aa28360290a5"},
+    {file = "mypy-1.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f8722560a14cde92fdb1e31597760dc35f9f5524cce17836c0d22841830fd5b"},
+    {file = "mypy-1.15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1fbb8da62dc352133d7d7ca90ed2fb0e9d42bb1a32724c287d3c76c58cbaa9c2"},
+    {file = "mypy-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:d10d994b41fb3497719bbf866f227b3489048ea4bbbb5015357db306249f7980"},
+    {file = "mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e"},
+    {file = "mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43"},
 ]
 
 [package.dependencies]
-mypy-extensions = ">=1.0.0"
+mypy_extensions = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = ">=4.1.0"
+typing_extensions = ">=4.6.0"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
+faster-cache = ["orjson"]
 install-types = ["pip"]
 mypyc = ["setuptools (>=50)"]
 reports = ["lxml"]
@@ -71,13 +77,43 @@ files = [
 
 [[package]]
 name = "tomli"
-version = "2.0.1"
+version = "2.2.1"
 description = "A lil' TOML parser"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+    {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
+    {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
+    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a"},
+    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee"},
+    {file = "tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e"},
+    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4"},
+    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106"},
+    {file = "tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8"},
+    {file = "tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff"},
+    {file = "tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b"},
+    {file = "tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea"},
+    {file = "tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8"},
+    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192"},
+    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222"},
+    {file = "tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77"},
+    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6"},
+    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd"},
+    {file = "tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e"},
+    {file = "tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98"},
+    {file = "tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4"},
+    {file = "tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7"},
+    {file = "tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c"},
+    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13"},
+    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281"},
+    {file = "tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272"},
+    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140"},
+    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2"},
+    {file = "tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744"},
+    {file = "tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec"},
+    {file = "tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69"},
+    {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
+    {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
 ]
 
 [[package]]
@@ -93,5 +129,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10,<3.13"
-content-hash = "4709d1d8fa55be66676bf9d577adde37c8ba4dd855ceebf0b1ec1c0c2ce1d6ad"
+python-versions = ">=3.10,<3.14"
+content-hash = "9e3a0b4ee9194164f1ccd0af48824760788e75ceaf9eb4732eea808261c30fda"

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -99,7 +99,7 @@ def populate_partition_fields_for_existing_data(doctype=None, settings=None):
 				continue
 
 			unpopulated_count = frappe.db.count(
-				child_doctype, filters={partition_field: ["is", "null"]}
+				child_doctype, filters={partition_field: ["is", "null"], "parenttype": doctype}
 			)
 
 			if unpopulated_count == 0:

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -194,8 +194,7 @@ def modify_primary_key(table_name, partition_field):
 		)
 
 
-def get_partition_doctypes_extended():
-	partition_doctypes = frappe.get_hooks("partition_doctypes")
+def get_partition_doctypes_extended(partition_doctypes):
 	partition_doctypes_extended = {}
 
 	for doctype, settings in partition_doctypes.items():
@@ -229,14 +228,21 @@ def get_date_range(doctype, field):
 	return None, None
 
 
-def create_partition():
+def create_partition(doctype=None):
 	partition_doctypes = frappe.get_hooks("partition_doctypes")
+
+	if doctype:
+		if doctype in partition_doctypes:
+			partition_doctypes = {doctype: partition_doctypes.get(doctype)}
+		else:
+			print(f"\033[31mERROR: {doctype} not in partition_doctypes hook.\033[0m")
+			return
 
 	# Creates the field for child doctypes if it doesn't exists yet
 	for doctype, settings in partition_doctypes.items():
 		add_custom_field(doctype, settings.get("field", "posting_date")[0])
 
-	for doctype, settings in get_partition_doctypes_extended().items():
+	for doctype, settings in get_partition_doctypes_extended(partition_doctypes).items():
 		table_name = get_table_name(doctype)
 		partition_field = settings.get("field", "posting_date")[0]
 		partition_by = settings.get("partition_by", "fiscal_year")[0]

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -27,7 +27,9 @@ def add_custom_field(parent_doctype, partition_field):
 			"Custom Field", filters={"dt": child_doctype, "fieldname": partition_field}
 		):
 			continue
-		print(f"Adding {partition_field} to {child_doctype} for {parent_doctype}")
+		print(
+			f"\033[34mINFO: Adding {partition_field} to {child_doctype} for {parent_doctype}\033[0m"
+		)
 		custom_field = frappe.get_doc(
 			{
 				"doctype": "Custom Field",
@@ -44,7 +46,9 @@ def add_custom_field(parent_doctype, partition_field):
 		try:
 			custom_field.insert()
 		except Exception as e:
-			print(f"Error adding {partition_field} to {child_doctype} for {parent_doctype}: {e}")
+			print(
+				f"\033[31mERROR: error adding {partition_field} to {child_doctype} for {parent_doctype}: {e}\033[0m"
+			)
 			continue
 
 
@@ -101,11 +105,11 @@ def populate_partition_fields_for_existing_data(doctype=None, settings=None):
 				)
 				frappe.db.commit()
 				print(
-					f"Partition field {partition_field} in child table {child_doctype} populated."
+					f"\033[32mSUCCESS: Partition field {partition_field} in child table {child_doctype} populated.\033[0m"
 				)
 			except Exception as e:
 				print(
-					f"Error populationg partition field {partition_field} in child table {child_doctype}: {e}"
+					f"\033[31mERROR: Error populating partition field {partition_field} in child table {child_doctype}: {e}.\033[0m"
 				)
 
 
@@ -121,7 +125,7 @@ def primary_key_exists(table_name):
 		)
 		return result[0][0] > 0
 	except Exception as e:
-		print(f"Error checking primary key existence: {e}")
+		print(f"\033[31mERROR: error checking primary key existence: {e}\033[0m")
 		return False
 
 
@@ -136,7 +140,7 @@ def modify_primary_key(table_name, partition_field):
 
 			if partition_field in current_pk_columns:
 				print(
-					f"Primary key in table {table_name} already includes the partition field `{partition_field}`. No changes needed."
+					f"\033[34mINFO: primary key in table {table_name} already includes the partition field `{partition_field}`. No changes needed.\033[0m"
 				)
 				return
 
@@ -167,9 +171,13 @@ def modify_primary_key(table_name, partition_field):
 			"""
 			frappe.db.sql(add_pk_sql)
 			frappe.db.commit()
-			print(f"Primary key modified in table {table_name} to include columns: {pk_columns}")
+			print(
+				f"\033[32mSUCCESS: Primary key modified in table {table_name} to include columns: {pk_columns}.\033[0m"
+			)
 	except Exception as e:
-		print(f"Error modifying primary key in table {table_name}: {e}")
+		print(
+			f"\033[31mERROR: Error modifying primary key in table {table_name}: {e}.\033[0m"
+		)
 
 
 def get_partition_doctypes_extended():
@@ -193,7 +201,7 @@ def partition_exists(table_name, partition_name):
 		)
 		return bool(result)
 	except Exception as e:
-		print(f"Error checking partition existence: {e}")
+		print(f"\033[31mERROR: Error checking partition existence: {e}.\033[0m")
 		return False
 
 
@@ -228,7 +236,7 @@ def create_partition():
 
 		start_year, end_year = get_date_range(doctype, partition_field)
 		if start_year is None or end_year is None:
-			print(f"No data found for {doctype}, skipping partitioning.")
+			print(f"\033[34mINFO: No data found for {doctype}, skipping partitioning.\033[0m")
 			continue
 
 		if partition_by == "field":
@@ -240,7 +248,7 @@ def create_partition():
 				partition_name = f"{frappe.scrub(doctype)}_{partition_field}_{partition_value}"
 				if partition_name not in [p.split()[1] for p in partitions]:
 					partitions.append(f"PARTITION {partition_name} VALUES IN ({partition_value})")
-					print(f"Creating partition {partition_name} for {doctype}")
+					print(f"\033[34mINFO: Creating partition {partition_name} for {doctype}.\033[0m")
 
 			if not partitions:
 				continue
@@ -268,7 +276,7 @@ def create_partition():
 					if partition_exists(table_name, partition_name):
 						continue
 					partitions.append(f"PARTITION {partition_name} VALUES LESS THAN ({year_end}), ")
-					print(f"Creating partition {partition_name} for {doctype}")
+					print(f"\033[34mINFO: Creating partition {partition_name} for {doctype}.\033[0m")
 
 			if not partitions:
 				continue
@@ -290,7 +298,7 @@ def create_partition():
 						partitions.append(
 							f"PARTITION {partition_name} VALUES LESS THAN ({quarter_code + 1})"
 						)
-						print(f"Creating partition {partition_name} for {doctype}")
+						print(f"\033[34mINFO: Creating partition {partition_name} for {doctype}.\033[0m")
 
 				elif partition_by == "month":
 					partition_sql = f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR(`{partition_field}`) * 100 + MONTH(`{partition_field}`)) (\n"
@@ -302,10 +310,12 @@ def create_partition():
 						partitions.append(
 							f"PARTITION {partition_name} VALUES LESS THAN ({month_code + 1})"
 						)
-						print(f"Creating partition {partition_name} for {doctype}")
+						print(f"\033[34mINFO: Creating partition {partition_name} for {doctype}.\033[0m")
 
 			if not partitions:
-				print(f"No need to create partitions for {doctype}, skipping partitioning.")
+				print(
+					f"\033[34mINFO: No need to create partitions for {doctype}, skipping partitioning.\033[0m"
+				)
 				continue
 
 			partition_sql += ",\n".join(partitions)
@@ -314,6 +324,6 @@ def create_partition():
 		try:
 			frappe.db.sql(partition_sql)
 			frappe.db.commit()
-			print(f"Partitioning for {doctype} completed successfully.")
+			print(f"\033[32mSUCCESS: Partitioning for {doctype} completed successfully.\033[0m")
 		except Exception as e:
-			print(f"Error while partitioning {doctype}: {e}")
+			print(f"\033[31mERROR: Error while partitioning {doctype}: {e}.\033[0m")

--- a/test_utils/utils/create_partition.py
+++ b/test_utils/utils/create_partition.py
@@ -145,18 +145,19 @@ def get_partition_doctypes_extended():
 def create_partition():
 	"""
 	partition_doctypes = {
-	                "Sales Order": {
-	                                "field": "transaction_date",
-	                                "partition_by": "fiscal_year",  # Options: "fiscal_year", "quarter", "month", "field"
-	                },
-	                "Sales Invoice": {
-	                                "field": "posting_date",
-	                                "partition_by": "fiscal_year",  # Options: "fiscal_year", "quarter", "month", "field"
-	                },
-	                "Item": {
-	                                "field": "disabled",
-	                                "partition_by": "field",  # Options: "fiscal_year", "quarter", "month", "field"
-	                },
+	        "Sales Order": {
+	                "field": "transaction_date",
+	                "partition_by": "fiscal_year",  # Options: "fiscal_year", "quarter", "month", "field"
+	        },
+	        "Sales Invoice": {
+	                "field": "posting_date",
+	                "partition_by": "fiscal_year",  # Options: "fiscal_year", "quarter", "month", "field"
+	        },
+	        "Item": {
+	                "field": "disabled",
+	                "partition_by": "field",  # Options: "fiscal_year", "quarter", "month", "field"
+	        },
+	}
 	"""
 	partition_doctypes = frappe.get_hooks("partition_doctypes")
 
@@ -184,9 +185,10 @@ def create_partition():
 			)
 			for value in partition_values:
 				partition_value = value[partition_field]
-				partition_name = f"{partition_field}_{partition_value}"
+				partition_name = f"{frappe.scrub(doctype)}_{partition_field}_{partition_value}"
 				if partition_name not in [p.split()[1] for p in partitions]:
 					partitions.append(f"PARTITION {partition_name} VALUES IN ({partition_value})")
+					print(f"Creating partition {partition_name} for {doctype}")
 
 			if not partitions:
 				continue
@@ -198,34 +200,39 @@ def create_partition():
 			partition_sql += ");"
 		else:
 			partitions = []
+			partition_sql = ""
 			for fiscal_year in fiscal_years:
 				year_start = fiscal_year.get("year_start_date").year
 				year_end = fiscal_year.get("year_end_date").year + 1
+				partition_name = f"{frappe.scrub(doctype)}_fiscal_year_{year_start}"
 
 				if partition_by == "fiscal_year":
 					partition_sql = (
 						f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR(`{partition_field}`)) (\n"
 					)
 					for fiscal_year in fiscal_years:
-						partitions.append(
-							f"PARTITION fiscal_year_{year_start} VALUES LESS THAN ({year_end}), "
-						)
+						partitions.append(f"PARTITION {partition_name} VALUES LESS THAN ({year_end}), ")
+						print(f"Creating partition {partition_name} for {doctype}")
 
 				elif partition_by == "quarter":
 					partition_sql = f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR(`{partition_field}`) * 10 + QUARTER(`{partition_field}`)) (\n"
 					for quarter in range(1, 5):
+						partition_name = f"{frappe.scrub(doctype)}_{year_start}_quarter_{quarter}"
 						quarter_code = year_start * 10 + quarter
 						partitions.append(
-							f"PARTITION {year_start}_quarter_{quarter} VALUES LESS THAN ({quarter_code + 1})"
+							f"PARTITION {partition_name} VALUES LESS THAN ({quarter_code + 1})"
 						)
+						print(f"Creating partition {partition_name} for {doctype}")
 
 				elif partition_by == "month":
 					partition_sql = f"ALTER TABLE `{table_name}` PARTITION BY RANGE (YEAR(`{partition_field}`) * 100 + MONTH(`{partition_field}`)) (\n"
 					for month in range(1, 13):
+						partition_name = f"{frappe.scrub(doctype)}_{year_start}_month_{month:02d}"
 						month_code = year_start * 100 + month
 						partitions.append(
-							f"PARTITION {year_start}_month_{month:02d} VALUES LESS THAN ({month_code + 1})"
+							f"PARTITION {partition_name} VALUES LESS THAN ({month_code + 1})"
 						)
+						print(f"Creating partition {partition_name} for {doctype}")
 
 				elif partition_by == "field":
 					field_partitions = []
@@ -234,11 +241,12 @@ def create_partition():
 					)
 					for value in partition_values:
 						partition_value = value[partition_field]
-						partition_name = f"{partition_field}_{partition_value}"
+						partition_name = f"{frappe.scrub(doctype)}_{partition_field}_{partition_value}"
 						if partition_name not in [p.split()[1] for p in partitions]:
 							field_partitions.append(
 								f"PARTITION {partition_name} VALUES IN ({partition_value})"
 							)
+							print(f"Creating partition {partition_name} for {doctype}")
 
 					if not field_partitions:
 						continue
@@ -247,6 +255,10 @@ def create_partition():
 						f"ALTER TABLE `{table_name}` PARTITION BY LIST (`{partition_field}`) (\n"
 					)
 					partitions += field_partitions
+
+			if not partition_sql:
+				print(f"No data for {doctype}, skipping partitioning.")
+				continue
 
 			partition_sql += ",\n".join(partitions)
 			partition_sql += ");"

--- a/test_utils/utils/restore_partitions.py
+++ b/test_utils/utils/restore_partitions.py
@@ -44,7 +44,7 @@ def dump_schema_only(site, backup_dir, compress):
 				process = subprocess.run(command, shell=True, capture_output=True, check=True)
 				f.write(process.stdout)
 			print(
-				f"Schema dump completed and compressed successfully. File saved as {compressed_file_path}."
+				f"\033[32mSUCCESS: Schema dump completed and compressed successfully. File saved as {compressed_file_path}.\033[0m"
 			)
 			return compressed_file_path
 		else:
@@ -52,12 +52,14 @@ def dump_schema_only(site, backup_dir, compress):
 				subprocess.run(
 					command, shell=True, stdout=f, stderr=subprocess.PIPE, text=True, check=True
 				)
-			print(f"Schema dump completed successfully. File saved as {schema_dump_file}.")
+			print(
+				f"\033[32mSUCCESS: Schema dump completed successfully. File saved as {schema_dump_file}.\033[0m"
+			)
 			return schema_dump_file
 	except subprocess.CalledProcessError as e:
-		print(f"Error during schema dump: {e.stderr}")
+		print(f"\033[31mERROR: Error during schema dump: {e.stderr}.: {e}.\033[0m")
 	except Exception as e:
-		print(f"Unexpected error: {e}")
+		print(f"\033[31mERROR: Unexpected error: {e}.\033[0m")
 
 
 def backup_full_database(site, backup_dir, compress):
@@ -88,7 +90,7 @@ def backup_full_database(site, backup_dir, compress):
 			result = subprocess.run(command, capture_output=True, text=True, check=False)
 
 			if result.returncode != 0:
-				print(f"Error occurred: {result.stderr}")
+				print(f"\033[31mERROR: Error occurred: {result.stderr}.\033[0m")
 				raise Exception(f"Backup failed with return code {result.returncode}")
 
 			if compress:
@@ -98,14 +100,16 @@ def backup_full_database(site, backup_dir, compress):
 						f_out.writelines(f_in)
 				os.remove(full_backup_file)
 				print(
-					f"Backup completed and compressed successfully. File saved as {compressed_file_path}."
+					f"\033[32mSUCCESS: Backup completed and compressed successfully. File saved as {compressed_file_path}.\033[0m"
 				)
 				return compressed_file_path
 			else:
-				print(f"Backup completed successfully. File saved as {full_backup_file}.")
+				print(
+					f"\033[32mSUCCESS: Backup completed successfully. File saved as {full_backup_file}.\033[0m"
+				)
 				return full_backup_file
 	except Exception as e:
-		print(f"Unexpected error: {e}")
+		print(f"\033[31mERROR: Unexpected error: {e}.\033[0m")
 
 
 def merge_sql_files(schema_dump_path, full_backup_path, backup_dir, compress):
@@ -118,7 +122,7 @@ def merge_sql_files(schema_dump_path, full_backup_path, backup_dir, compress):
 		]
 		result = subprocess.run(command, capture_output=True, text=True, check=False)
 		if result.returncode != 0:
-			print(f"Error occurred: {result.stderr}")
+			print(f"\033[31mERROR: Error occurred: {result.stderr}.\033[0m")
 			raise Exception(f"Merge failed with return code {result.returncode}")
 
 		if compress:
@@ -127,13 +131,15 @@ def merge_sql_files(schema_dump_path, full_backup_path, backup_dir, compress):
 				with gzip.open(compressed_file_path, "wb") as gz_file:
 					shutil.copyfileobj(output_file, gz_file)
 			os.remove(output_path)
-			print(f"Files merged successfully and compressed into {compressed_file_path}.")
+			print(
+				f"\033[32mSUCCESS: Files merged successfully and compressed into {compressed_file_path}.\033[0m"
+			)
 			return compressed_file_path
 		else:
-			print(f"Files merged successfully into {output_path}")
+			print(f"\033[32mSUCCESS: Files merged successfully into {output_path}.\033[0m")
 			return output_path
 	except Exception as e:
-		print(f"An error occurred: {e}")
+		print(f"\033[31mERROR: Unexpected error: {e}.\033[0m")
 
 
 def restore_database(site, backup_file, bubble_backup):
@@ -155,12 +161,12 @@ def restore_database(site, backup_file, bubble_backup):
 			result = subprocess.run(command, capture_output=True, text=True, check=False)
 
 			if result.returncode != 0:
-				print(f"Error occurred: {result.stderr}")
+				print(f"\033[31mERROR: Error occurred: {result.stderr}.\033[0m")
 				raise Exception(f"Restore failed with return code {result.returncode}")
 
-			print("Restore completed successfully.")
+			print("\033[32mSUCCESS: Restore completed successfully.\033[0m")
 		except Exception as e:
-			print(f"Unexpected error: {e}")
+			print(f"\033[31mERROR: Unexpected error: {e}.\033[0m")
 	else:
 		try:
 			command = [
@@ -175,12 +181,12 @@ def restore_database(site, backup_file, bubble_backup):
 			result = subprocess.run(command, capture_output=True, text=True, check=False)
 
 			if result.returncode != 0:
-				print(f"Error occurred: {result.stderr}")
+				print(f"\033[31mERROR: Error occurred: {result.stderr}.\033[0m")
 				raise Exception(f"Restore failed with return code {result.returncode}")
 
-			print("Restore completed successfully.")
+			print("\033[32mSUCCESS: Restore completed successfully.\033[0m")
 		except Exception as e:
-			print(f"Unexpected error: {e}")
+			print(f"\033[31mERROR: Unexpected error: {e}.\033[0m")
 
 
 def get_last_n_partitions_for_tables(table_names, n):
@@ -260,19 +266,21 @@ def backup_partition(site, table, current_partition, compress):
 					shutil.copyfileobj(f_in, f_out)
 			os.remove(output_file)
 			print(
-				f"Backup of partition {current_partition} completed and compressed. File saved as {compressed_file_path}."
+				f"\033[32mSUCCESS: Backup of partition {current_partition} completed and compressed. File saved as {compressed_file_path}.\033[0m"
 			)
 			return compressed_file_path
 		else:
 			print(
-				f"Backup of partition {current_partition} completed successfully. File saved as {output_file}."
+				f"\033[32mSUCCESS: Backup of partition {current_partition} completed successfully. File saved as {output_file}.\033[0m"
 			)
 			return output_file
 	except pymysql.MySQLError as e:
-		print(f"Error during backup: {e}")
+		print(
+			f"\033[31mERROR: Error during backup of table {table}, partition {current_partition}: {e}.\033[0m"
+		)
 		return None
 	except Exception as e:
-		print(f"Unexpected error: {e}")
+		print(f"\033[31mERROR: Unexpected error: {e}.\033[0m")
 		return None
 
 
@@ -305,11 +313,13 @@ def restore_partition(site, table, partition_bkp_file):
 		connection.commit()
 		cursor.close()
 		connection.close()
-		print(f"Data imported successfully from {partition_bkp_file}.")
+		print(
+			f"\033[32mSUCCESS: Data imported successfully from {partition_bkp_file}.\033[0m"
+		)
 	except pymysql.MySQLError as e:
-		print(f"Error during import {partition_bkp_file}: {e}")
+		print(f"\033[31mERROR: Error during import {partition_bkp_file}: {e}.\033[0m")
 	except Exception as e:
-		print(f"Unexpected error {partition_bkp_file}: {e}")
+		print(f"\033[31mERROR: Unexpected error {partition_bkp_file}: {e}.\033[0m")
 
 
 def restore_partitions(
@@ -352,7 +362,9 @@ def get_site_config_data(site_name):
 		return site_config
 
 	except Exception as e:
-		print(f"Error reading site config for site {site_name}: {str(e)}")
+		print(
+			f"\033[31mERROR: Error reading site config for site {site_name}: {str(e)}.\033[0m"
+		)
 		return None
 
 
@@ -362,9 +374,9 @@ def delete_backup_files(backup_dir):
 			file_path = os.path.join(backup_dir, filename)
 			if any(filename.endswith(ext) for ext in [".sql", ".gz", ".csv"]):
 				os.remove(file_path)
-				print(f"Deleted file: {file_path}")
+				print(f"\033[34mINFO: Deleted file: {file_path}.\033[0m")
 	except Exception as e:
-		print(f"Error while deleting backup files: {str(e)}")
+		print(f"\033[31mERROR: Error while deleting backup files: {str(e)}.\033[0m")
 
 
 def restore(
@@ -378,10 +390,10 @@ def restore(
 	partitioned_doctypes_to_restore=None,
 	last_n_partitions=1,
 	compress=False,
-	delete_files=False,
+	delete_files=True,
 ):
 	if not to_site and not to_database:
-		print("Should specify to_site or to_database")
+		print("\033[31mERROR: Should specify to_site or to_database.\033[0m")
 		return
 
 	from_site_config = get_site_config_data(from_site)
@@ -440,8 +452,7 @@ def bubble_backup(
 	backup_dir="/tmp",
 	partitioned_doctypes_to_restore=None,
 	last_n_partitions=1,
-	compress=False,
-	delete_files=False,
+	delete_files=True,
 	keep_temp_db=False,
 ):
 	temp_db_name = f"temp_restore_{datetime.datetime.now().strftime('%Y%m%d%H%M')}"
@@ -458,7 +469,7 @@ def bubble_backup(
 			connection.commit()
 		finally:
 			connection.close()
-			print(f"Temporary database {temp_db_name} created.")
+			print(f"\033[32mSUCCESS: Temporary database {temp_db_name} created.\033[0m")
 
 		from_site = os.path.basename(frappe.get_site_path())
 		restore(
@@ -471,13 +482,13 @@ def bubble_backup(
 			backup_dir=backup_dir,
 			partitioned_doctypes_to_restore=partitioned_doctypes_to_restore,
 			last_n_partitions=last_n_partitions,
-			compress=compress,
+			compress=False,
 			delete_files=delete_files,
 		)
-		bubble_bkp_name = f"./{from_site}/private/backups/bubble_{datetime.datetime.now().strftime('%Y%m%d%H%M')}.sql"
+		bubble_bkp_name = f"./{from_site}/private/backups/{datetime.datetime.now().strftime('%Y%m%d%H%M')}_bubble.sql"
 		dump_command = f"mysqldump -u {mariadb_user} -h {mariadb_host} -p{mariadb_password} {temp_db_name} | gzip > {bubble_bkp_name}.gz"
 		subprocess.run(dump_command, shell=True, check=True)
-		print(f"Backup SQL dump saved to {bubble_bkp_name}")
+		print(f"\033[32mSUCCESS: Backup SQL dump saved to {bubble_bkp_name}.\033[0m")
 
 	finally:
 		if not keep_temp_db:
@@ -488,4 +499,4 @@ def bubble_backup(
 			cursor.execute(f"DROP DATABASE {temp_db_name};")
 			cursor.close()
 			connection.close()
-			print(f"Temporary database {temp_db_name} deleted.")
+			print(f"\033[34mINFO: Temporary database {temp_db_name} deleted.\033[0m")

--- a/test_utils/utils/restore_partitions.py
+++ b/test_utils/utils/restore_partitions.py
@@ -408,6 +408,7 @@ def restore(
 	)
 
 	if to_site:
+		bubble_backup = False
 		to_site_config = get_site_config_data(to_site)
 		to_site_config.update(
 			{

--- a/test_utils/utils/restore_partitions.py
+++ b/test_utils/utils/restore_partitions.py
@@ -15,7 +15,7 @@ import frappe
 
 def get_mariadb_host():
 	try:
-		db_host = frappe.conf.db_host
+		db_host = get_config().db_host
 		if db_host in ["localhost", "127.0.0.1"]:
 			return db_host
 
@@ -465,6 +465,12 @@ def restore(
 		delete_backup_files(backup_dir)
 
 
+def get_config():
+	site_path = os.path.join(os.getcwd(), "common_site_config.json")
+	with open(site_path) as f:
+		return frappe._dict(json.load(f))
+
+
 def bubble_backup(
 	backup_dir="/tmp",
 	partitioned_doctypes_to_restore=None,
@@ -473,9 +479,10 @@ def bubble_backup(
 	keep_temp_db=False,
 ):
 	mariadb_host = get_mariadb_host()
-	mariadb_port = frappe.utils.cint(frappe.conf.db_port) or 3306
-	mariadb_user = frappe.conf.root_login
-	mariadb_password = frappe.conf.root_password
+	config = get_config()
+	mariadb_port = frappe.utils.cint(config.db_port) or 3306
+	mariadb_user = config.root_login
+	mariadb_password = config.root_password
 
 	if not mariadb_user or not mariadb_password:
 		print(

--- a/test_utils/utils/restore_partitions.py
+++ b/test_utils/utils/restore_partitions.py
@@ -434,7 +434,6 @@ def restore(
 
 
 def bubble_backup(
-	from_site,
 	mariadb_user,
 	mariadb_password,
 	mariadb_host="localhost",
@@ -461,8 +460,9 @@ def bubble_backup(
 			connection.close()
 			print(f"Temporary database {temp_db_name} created.")
 
+		from_site = os.path.basename(frappe.get_site_path())
 		restore(
-			from_site,
+			frappe.local.site,
 			mariadb_user,
 			mariadb_password,
 			to_site=None,

--- a/test_utils/utils/restore_partitions.py
+++ b/test_utils/utils/restore_partitions.py
@@ -481,8 +481,11 @@ def bubble_backup(
 
 	finally:
 		if not keep_temp_db:
+			connection = pymysql.connect(
+				host=mariadb_host, user=mariadb_user, password=mariadb_password
+			)
+			cursor = connection.cursor()
 			cursor.execute(f"DROP DATABASE {temp_db_name};")
+			cursor.close()
+			connection.close()
 			print(f"Temporary database {temp_db_name} deleted.")
-
-		cursor.close()
-		connection.close()


### PR DESCRIPTION
- New function `populate_partition_fields_for_existing_data`: Sets the new field created in child tables with data from the parent DocType.
- Changes in `create_partition`:
    - Previously, partitions were created for each Fiscal Year. Now, for each DocType to be partitioned, the process looks back to the first year with data and creates partitions from that year to the current year (for the `partition_by` options: month and quarter).
    - Before creating a partition, a check is performed to ensure it does not already exist.
    - Accepts a doctype parameter to create a partition for the given doctype, which must be defined in the `partition_doctypes` hook.
- Better messages:

![Captura de pantalla 2025-01-09 a la(s) 4 51 52 p  m](https://github.com/user-attachments/assets/1d5a8804-8ce4-4073-81d0-e51c64e12251)


