### PR TITLE
chore: bump python version to support 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ update_pre_commit_config = "test_utils.pre_commit.update_pre_commit_config:main"
 create_partition = "test_utils.utils.create_partition:create_partition"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10,<3.14"
 mypy = "^1.10.1"
 toml = "^0.10.2"
 


### PR DESCRIPTION
Closes #99 

Very simple tweak to the code base but required some installation testing. To test, I created a new bench with Python 3.13.1 (needed the Frappe and ERPNext `develop` branches), then installed a [dummy app](https://github.com/HKuz/test_tu) on my personal GH that has test_utils as a dependency. (I needed to set it to a version on my fork supporting 3.13).

Installation worked and I ran the test setup script for the dummy app and successfully created a company with an IFRS COA and the test_utils customers.

Other testing area may include the partition work.