### PR TITLE
feat: adjust Farm COA inv adj and account types

### DIFF
--- a/test_utils/fixtures/farm_coa.json
+++ b/test_utils/fixtures/farm_coa.json
@@ -38,7 +38,8 @@
 				},
 				"Loans and Advances (Assets)": {
 					"Employee Advances": {
-						"account_number": "1610"
+						"account_number": "1610",
+						"account_type": "Payable"
 					},
 					"account_number": "1600"
 				},
@@ -118,7 +119,7 @@
 						"account_type": "Expenses Included In Valuation",
 						"account_number": "5118"
 					},
-					"Inventory Adjustment": {
+					"Inventory Write Off": {
 						"account_type": "Stock Adjustment",
 						"account_number": "5119"
 					},


### PR DESCRIPTION
Closes #145 

Adjusts the name of the account type "Stock Adjustment" account from "Inventory Adjustment" to "Inventory Write Off" as proposed in the issue. Since Test Utils owns this COA (vs modifying one from ERPNext), I did the change directly in the JSON.

I also went through all the Company doc's Account link fields (plus HRMS ones) and made sure the Farm COA had an account with the account type that the field's filter is looking for - only had to add an account type to the Employee Advances to conform with ERPNext's standard with Numbers.

There were two account type filters that are not covered in Farm COA, but they also are not in ERPNext's Standard with Numbers - I can add account with these account types if needed:
- Field "Round Off For Opening" is looking for account type "Round Off for Opening"
- Field "Service Received But Not Billed" is looking for account type "Service Received But Not Billed"