### PR TITLE
Fix: unreadable "Track Overrides" PR comment

### DIFF
--- a/actions/track_overrides/action.yml
+++ b/actions/track_overrides/action.yml
@@ -41,13 +41,11 @@ runs:
           if [[ -n "${{ github.base_ref }}" ]]; then
             base_branch="${{ github.base_ref }}"
           fi
-          changed_methods=$(track_overrides --directory ${{ github.workspace }} --app ${{ inputs.app }} --base-branch "$base_branch" 2>&1)
+          changed_methods=$(track_overrides --directory ${{ github.workspace }} --app ${{ inputs.app }} --base-branch "$base_branch" --no-color 2>&1)
           exitcode=$?
           set -e
 
-          # Sanitize the diff content before storing it (escape special characters)
-          sanitized_methods=$(echo "$changed_methods" | sed 's/\r//g' | sed 's/\n/\\n/g' | sed 's/\"/\\\"/g')
-          echo "$sanitized_methods" > diff_output.txt
+          printf '%s\n' "$changed_methods" > diff_output.txt
 
           if [[ $exitcode -ne 0 ]] && [[ -n "$changed_methods" ]]; then
             echo "Override methods have changed in the upstream repository."
@@ -66,8 +64,8 @@ runs:
           const diffFilePath = './diff_output.txt';
 
           if (fs.existsSync(diffFilePath)) {
-            const diffContent = fs.readFileSync(diffFilePath, 'utf8');
-            const commentBody = `The following override methods have changed in the upstream repository:\n\n${diffContent}\n`;
+            const diffContent = fs.readFileSync(diffFilePath, 'utf8').trimEnd();
+            const commentBody = `The following override methods have changed in the upstream repository:\n\n\`\`\`diff\n${diffContent}\n\`\`\`\n`;
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/test_utils/pre_commit/track_overrides.py
+++ b/test_utils/pre_commit/track_overrides.py
@@ -48,10 +48,12 @@ def get_last_commit_hash_for_file_in_branch(repo_url, file_path, base_branch):
 	return commits[0]["sha"] if commits else None
 
 
-def print_diff(diff_text):
+def print_diff(diff_text, color=True):
 	diff_lines = diff_text.splitlines()
 	for line in diff_lines:
-		if line.startswith("+++") or line.startswith("---"):
+		if not color:
+			print(line)
+		elif line.startswith("+++") or line.startswith("---"):
 			print("\033[32m" + line)
 		elif line.startswith("@@"):
 			print("\033[36m" + line)
@@ -124,6 +126,10 @@ def main(argv: Sequence[str] = None):
 	parser.add_argument(
 		"--base-branch", action="append", help="Base branch to compare against"
 	)
+	parser.add_argument(
+		"--no-color",
+		action="store_true",
+	)
 	args = parser.parse_args(argv)
 
 	if not args.base_branch:
@@ -153,7 +159,7 @@ def main(argv: Sequence[str] = None):
 			)
 			for change in changed_methods:
 				print(change["title"])
-				print_diff(change["diff"])
+				print_diff(change["diff"], color=not args.no_color)
 				print("")
 			sys.exit(1)
 	sys.exit(0)


### PR DESCRIPTION
`track_overrides`'s diff was colorized with ANSI (for terminal use) and then pasted as-is into the PR comment, where Markdown doesn't interpret it. A quote-escaping `sed` (for a JSON format that's never used) added literal `\"` on top.

**Fix**: the Action now invokes the CLI with `--no-color` (the local hook stays colorized), wraps the diff in a ` ```diff ` block, and replaces the `sed` with `printf '%s\n' "$changed_methods" > diff_output.txt`.

Eg: https://github.com/agritheory/cloud_storage/pull/140#issuecomment-5241531737

## Before

```
The following override methods have changed in the upstream repository:


[PRE-COMMIT HOOK] Method changes detected! Please review before committing.
cloud_storage: `get_content` in `frappe/core/doctype/file/file.py` has changed:
^[[32m--- old
^[[32m+++ new
^[[36m@@ -2,6 +2,7 @@
^[[37m 		if self.is_folder:
^[[37m 			frappe.throw(_(\"Cannot get file contents of a Folder\"))
^[[37m 
^[[32m+		self.validate_file_path()
^[[37m 		if self.get(\"content\"):
^[[37m 			self._content = self.content
^[[37m 			if self.decode:
```

## After

````
The following override methods have changed in the upstream repository:

```diff
[PRE-COMMIT HOOK] Method changes detected! Please review before committing.
cloud_storage: `get_content` in `frappe/core/doctype/file/file.py` has changed:
--- old
+++ new
@@ -2,6 +2,7 @@
	if self.is_folder:
		frappe.throw(_("Cannot get file contents of a Folder"))

+	self.validate_file_path()
	if self.get("content"):
		self._content = self.content
		if self.decode:
```
````
